### PR TITLE
Update guideline-09.md: legal compliance

### DIFF
--- a/guideline-09.md
+++ b/guideline-09.md
@@ -10,6 +10,7 @@ This includes (but is not restricted to) the following examples:
 	<li>Implying users must pay to unlock included features</li>
 	<li>Creating accounts to generate fake reviews or support tickets (i.e. sockpuppeting)</li>
 	<li>Taking other developers’ plugins and presenting them as original work</li>
+	<li>Implying that a plugin can create, provide, or guarantee legal compliance</li>
 	<li>Utilizing the user’s server or resources without permission, such as part of a botnet or crypto-mining</li>
 	<li>Violations of the <a href="https://make.wordpress.org/community/handbook/wordcamp-organizer/planning-details/code-of-conduct/">WordCamp code of conduct<a></li>
 	<li>Violations of the <a href="https://wordpress.org/support/guidelines/">Forum Guidelines</a></li>


### PR DESCRIPTION
Proposed addition: **implying that a plugin can create, provide, automate, or guarantee legal compliance**

Over the years there have occasionally been plugins launched which have claimed to provide legal compliance (privacy, data protection, contracts, copyright, etc) either in its description, its title, or in its creators' promotion of the work. However, no plugin can provide legal compliance on any issue on its own. While compliance-focused plugins can automate certain processes, provide workflows for complex obligations, or support administrators on a wider compliance journey, they cannot create any legal position which would protect a site administrator, much less provide the confidence that users expect from the sites they use.

Allowing plugins to claim they can provide "compliance" is very dangerous. It casts the ecosystem as a place where administrators can essentially outsource their legal obligations to seemingly random developers with no regard for accuracy or credentials. It also risks positioning the ecosystem as a marketplace which allows these claims to exist in the first place, inviting hostile public scrutiny - and perhaps rightfully so.

For these reasons, I would like to see "implying that a plugin can create, provide, automate, or guarantee legal compliance" added to the list of illegal, dishonest, and morally offensive claims.