### PR TITLE
Clarify human readability

### DIFF
--- a/guideline-04.md
+++ b/guideline-04.md
@@ -1,3 +1,12 @@
 <h4>4. Code must be (mostly) human readable.</h4>
 
-Obscuring code by hiding it with techniques or systems similar to <code>p,a,c,k,e,r</code>'s obfuscate feature, uglify's mangle, or unclear naming conventions such as <code>$z12sdf813d</code>, is not permitted in the directory. Unfortunately, many people use such methods to try and hide malicious code, such as backdoors or tracking. In addition, WordPress code is intended for anyone to be able to learn from, edit, and adapt. Making code non-human readable forces future developers to face an unnecessary hurdle. Minified code may be used, however the non-minified versions should be included whenever possible. We recommend following <a href="https://make.wordpress.org/core/handbook/best-practices/coding-standards/">WordPress Core Coding Standards</a>
+Obscuring code by hiding it with techniques or systems similar to <code>p,a,c,k,e,r</code>'s obfuscate feature, uglify's mangle, or unclear naming conventions such as <code>$z12sdf813d</code>, is not permitted in the directory. Making code non-human readable forces future developers to face an unnecessary hurdle, as well as being a common vector for hidden, malicious code.
+
+We require developers to provide public, maintained access to their source code and any build tools in one of the following ways:
+
+<ul>
+    <li>Include the source code in the deployed plugin</li>
+    <li>A link in the readme to the development location</li>
+</ul>
+
+We strongly recommend you document how any development tools are to be used.


### PR DESCRIPTION
With the advent of larger and larger plugins, people are making more use of build tools such as npm to generate their distributed production code. In order to balance the need to keep plugin sizes smaller while still encouraging open source development (i.e. forking etc), we will be requiring plugins to make the source code to any compressed files available.

For example, if you've made a Gutenberg plugin and used npm and webpack to compress and minify it, you must either include the source code within the published plugin _or_ provide access to a public maintained source that can be reviewed, studied, and yes, forked.

We strongly recommend you include directions on the use of any build tools (such as Create Guten Block in the above example), to encourage future developers.